### PR TITLE
Fix issue with volume swaggger UI generation

### DIFF
--- a/api/openstorage.yaml
+++ b/api/openstorage.yaml
@@ -646,7 +646,7 @@ paths:
             $ref: '#/definitions/Volume'
           examples:
              application/json: |-
-              [{
+              {
                     "id": "960911126757490171",
                     "readonly": false,
                     "locator": {
@@ -711,8 +711,7 @@ paths:
                     ],
                     "secure_device_path": "",
                     "background_processing": true
-                    }]
-                  }
+                    }
     put:
         summary: Change volume state
         description: |
@@ -733,7 +732,7 @@ paths:
                ``` json
                    {
                      "action": {
-                        "attach: 2"
+                        "attach": 2
                         }
                    }
               ```
@@ -741,7 +740,7 @@ paths:
                ``` json
                    {
                      "action": {
-                        "attach: 1"
+                        "attach": 1
                         }
                    }
               ```
@@ -749,8 +748,8 @@ paths:
                ``` json
                    {
                      "action": {
-                        "mount: 2",
-                        "mount_path:"/tmp""
+                        "mount": 2,
+                        "mount_path":"/tmp"
                         }
                    }
               ```
@@ -758,8 +757,8 @@ paths:
                ``` json
                    {
                      "action": {
-                        "mount: 1",
-                        "mount_path:"/tmp""
+                        "mount": 1,
+                        "mount_path":"/tmp"
                         }
                    }
               ```


### PR DESCRIPTION
Issue was due to unmatched parenthesis causing an invalid yaml entry.  